### PR TITLE
Serve statics with WhiteNoise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp/
 # logs and databases
 *.db
 *.log
+*.sqlite3

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ setup for flask
 pip install -r requirements.txt
 ```
 
+create a `DATABASE_URL` envvar with the database credentials, for example:
+```
+export DATABASE_URL=sqlite:///db.sqlite3
+```
+
 to fully run the project:
 ```console
 python run.py
@@ -17,4 +22,4 @@ python run.py
 run migrations
 ```console
 python manage.py db migrate
-``
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,11 @@
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_alembic import Alembic
+from whitenoise import WhiteNoise
 
 app = Flask(__name__)
 app.config.from_object('config')
+app.wsgi_app = WhiteNoise(app.wsgi_app, root='static/')
 
 db = SQLAlchemy(app)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask-Migrate==1.8.0
 Flask-Alembic==2.0.1
 Psycopg2==2.7.3
 gunicorn==19.7.0
+whitenoise==3.3.0


### PR DESCRIPTION
When serving the app via Heroku, Heroku is not a really great option for static files (assets, senator avatars etc.). [WhiteNoise](http://whitenoise.evans.io) is a simple solution to this — and that's what this tiny PR implements.

How to test it: running the app with `run.py` is not an option since WhiteNoise is not triggered in debug mode; thus my suggestion is to run like in production `gunicorn app:app` — if statics are being server properly, WhiteNoise is working.